### PR TITLE
[CHORE] Updating `onBeforeChange` args to match latest RFR api.

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -3,8 +3,6 @@ import { isAllowed, isServer } from './utils'
 
 export default {
   onBeforeChange: (dispatch, getState, { action }) => {
-    console.log('action')
-    console.log(action)
     const allowed = isAllowed(action.type, getState())
 
     if (!allowed) {

--- a/src/options.js
+++ b/src/options.js
@@ -2,7 +2,9 @@ import { redirect } from 'redux-first-router'
 import { isAllowed, isServer } from './utils'
 
 export default {
-  onBeforeChange: (dispatch, getState, action) => {
+  onBeforeChange: (dispatch, getState, { action }) => {
+    console.log('action')
+    console.log(action)
     const allowed = isAllowed(action.type, getState())
 
     if (!allowed) {


### PR DESCRIPTION
This PR updates the example `onBeforeChange` usage in the `connectRoute` `options` to account for the fact that the next `action` is now wrapped in an outer `bag` object with other data. The goal is to reduce unexpected behaviour for new RFR users :children_crossing: .

See note 9/9 in README: https://github.com/faceyspacey/redux-first-router/blob/rudy/README.md#L23
Diff: https://github.com/faceyspacey/redux-first-router/commit/012dbfa65288b99d2c10e8c6face1c6d9c46cc7d

Relates to: https://github.com/faceyspacey/redux-first-router-demo/issues/30